### PR TITLE
chore: bump reth 7b1b1fc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,12 +757,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9703ce68b97f8faae6f7739d1e003fc97621b856953cbcdbb2b515743f23288"
+checksum = "6fa8acead43cb238a7b7f47238c71137f4677a0b8d90e7e3be6e6ca59a28194e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "arrayvec",
  "derive_more",
  "nybbles",
  "serde",
@@ -998,6 +999,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "asn1_der"
@@ -1896,6 +1900,12 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
 name = "crossbeam-channel"
@@ -4535,6 +4545,10 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "op-alloy-consensus"
@@ -5478,7 +5492,7 @@ dependencies = [
 [[package]]
 name = "reth"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5550,7 +5564,7 @@ dependencies = [
 [[package]]
 name = "reth-auto-seal-consensus"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -5581,7 +5595,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5605,7 +5619,7 @@ dependencies = [
 [[package]]
 name = "reth-beacon-consensus"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -5640,7 +5654,7 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5673,7 +5687,7 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree-api"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "reth-consensus",
@@ -5686,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5710,7 +5724,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -5722,7 +5736,6 @@ dependencies = [
  "once_cell",
  "reth-ethereum-forks",
  "reth-network-peers",
- "reth-optimism-forks",
  "reth-primitives-traits",
  "reth-trie-common",
  "serde_json",
@@ -5731,7 +5744,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -5744,7 +5757,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "ahash",
  "alloy-eips",
@@ -5802,7 +5815,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -5812,7 +5825,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5829,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5845,7 +5858,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -5856,7 +5869,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -5870,7 +5883,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "auto_impl",
@@ -5881,7 +5894,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "reth-chainspec",
@@ -5893,7 +5906,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5917,7 +5930,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -5950,7 +5963,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -5975,7 +5988,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -6003,7 +6016,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -6018,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6042,7 +6055,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6066,7 +6079,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6088,7 +6101,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6117,7 +6130,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -6146,9 +6159,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-engine-local"
+version = "1.1.0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "eyre",
+ "futures-util",
+ "op-alloy-rpc-types-engine",
+ "reth-beacon-consensus",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-engine-primitives",
+ "reth-engine-service",
+ "reth-engine-tree",
+ "reth-ethereum-engine-primitives",
+ "reth-evm",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-payload-validator",
+ "reth-provider",
+ "reth-prune",
+ "reth-rpc-types-compat",
+ "reth-stages-api",
+ "reth-transaction-pool",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "reth-engine-primitives"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "reth-execution-types",
@@ -6161,7 +6205,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "futures",
  "pin-project",
@@ -6184,7 +6228,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6221,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -6252,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -6265,7 +6309,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6291,7 +6335,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -6308,7 +6352,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "eyre",
  "reth-chainspec",
@@ -6318,7 +6362,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "reth-chainspec",
@@ -6331,7 +6375,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6350,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6370,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "reth-basic-payload-builder",
@@ -6395,7 +6439,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -6405,7 +6449,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6427,7 +6471,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6446,7 +6490,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6462,7 +6506,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6477,7 +6521,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6513,7 +6557,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6526,7 +6570,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "serde",
  "serde_json",
@@ -6536,7 +6580,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6561,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6582,7 +6626,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -6599,7 +6643,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "bindgen",
  "cc",
@@ -6608,7 +6652,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "futures",
  "metrics",
@@ -6620,7 +6664,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
 ]
@@ -6628,7 +6672,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -6642,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6692,7 +6736,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -6715,7 +6759,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6735,7 +6779,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6750,7 +6794,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "humantime-serde",
  "reth-ethereum-forks",
@@ -6764,7 +6808,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6781,11 +6825,16 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
+ "alloy-rpc-types-engine",
+ "eyre",
+ "reth-beacon-consensus",
+ "reth-consensus",
  "reth-engine-primitives",
  "reth-evm",
  "reth-network-api",
+ "reth-node-core",
  "reth-node-types",
  "reth-payload-builder",
  "reth-payload-primitives",
@@ -6799,7 +6848,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -6822,6 +6871,7 @@ dependencies = [
  "reth-db-api",
  "reth-db-common",
  "reth-downloaders",
+ "reth-engine-local",
  "reth-engine-service",
  "reth-engine-tree",
  "reth-engine-util",
@@ -6863,7 +6913,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -6911,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "eyre",
  "reth-auto-seal-consensus",
@@ -6928,15 +6978,17 @@ dependencies = [
  "reth-payload-builder",
  "reth-primitives",
  "reth-provider",
+ "reth-revm",
  "reth-rpc",
  "reth-tracing",
  "reth-transaction-pool",
+ "revm",
 ]
 
 [[package]]
 name = "reth-node-events"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -6959,7 +7011,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "eyre",
  "http",
@@ -6983,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -6993,7 +7045,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-chainspec"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-chains",
  "alloy-genesis",
@@ -7012,7 +7064,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-cli"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7056,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-consensus"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "reth-chainspec",
@@ -7072,7 +7124,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-evm"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "op-alloy-consensus",
@@ -7096,7 +7148,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-forks"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7107,7 +7159,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-node"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7126,6 +7178,7 @@ dependencies = [
  "reth-chainspec",
  "reth-consensus",
  "reth-discv5",
+ "reth-engine-local",
  "reth-evm",
  "reth-network",
  "reth-node-api",
@@ -7146,6 +7199,7 @@ dependencies = [
  "reth-rpc-types-compat",
  "reth-tracing",
  "reth-transaction-pool",
+ "revm",
  "serde",
  "serde_json",
  "thiserror",
@@ -7155,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-payload-builder"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7189,7 +7243,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "reth-primitives",
@@ -7199,7 +7253,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-rpc"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7239,7 +7293,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7259,7 +7313,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7281,7 +7335,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-rpc-types",
  "reth-chainspec",
@@ -7292,7 +7346,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7328,7 +7382,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7352,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7395,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "itertools 0.13.0",
@@ -7421,7 +7475,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7435,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "reth-chainspec",
@@ -7451,7 +7505,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7517,7 +7571,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -7543,7 +7597,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-network",
  "alloy-rpc-types",
@@ -7579,7 +7633,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7610,7 +7664,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-eips",
@@ -7651,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7662,6 +7716,7 @@ dependencies = [
  "alloy-sol-types",
  "derive_more",
  "futures",
+ "itertools 0.13.0",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
@@ -7694,7 +7749,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -7707,7 +7762,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -7723,8 +7778,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types-compat"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
@@ -7739,7 +7795,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "bincode",
@@ -7775,7 +7831,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "aquamarine",
@@ -7801,7 +7857,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7814,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.3",
@@ -7836,7 +7892,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7848,7 +7904,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7867,7 +7923,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7880,7 +7936,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -7898,7 +7954,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -7908,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "clap",
  "eyre",
@@ -7923,8 +7979,9 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
@@ -7957,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7981,7 +8038,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8001,7 +8058,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8026,7 +8083,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=75dda1c#75dda1c398153b674c760402056ec52a8c2cceaf"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=7b1b1fc#7b1b1fcb3b632d8c877a3e761a77ae4d513c0c2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,45 +155,43 @@ alloy-signer-local = { version = "0.4", features = ["mnemonic"] }
 tokio = { version = "1.21", default-features = false }
 
 # reth
-reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c", features = [
+reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc", features = [
     "optimism",
 ] }
-reth-cli = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c", features = [
+reth-optimism-node = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc", features = [
     "optimism",
 ] }
-reth-optimism-node = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c", features = [
+reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc", features = [
     "optimism",
 ] }
-reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c", features = [
+reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc", features = [
     "optimism",
 ] }
-reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c", features = [
+reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc", features = [
     "optimism",
 ] }
-reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
-reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c", features = [
+reth-provider = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc", features = [
     "optimism",
 ] }
-reth-provider = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc", features = [
     "optimism",
 ] }
-reth-revm = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c", features = [
-    "optimism",
-] }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
-reth-network = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
-reth-network-types = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth.git", rev = "75dda1c" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-network = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-network-types = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth.git", rev = "7b1b1fc" }
 
 # rpc
 jsonrpsee = "0.24"

--- a/bin/odyssey/src/main.rs
+++ b/bin/odyssey/src/main.rs
@@ -34,7 +34,6 @@ use odyssey_walltime::{OdysseyWallTime, OdysseyWallTimeRpcApiServer};
 use reth_node_builder::{engine_tree_config::TreeConfig, EngineNodeLauncher};
 use reth_optimism_cli::Cli;
 use reth_optimism_node::{args::RollupArgs, node::OptimismAddOns};
-use reth_optimism_rpc::sequencer::SequencerClient;
 use reth_provider::{providers::BlockchainProvider2, CanonStateSubscriptions};
 use tracing::{info, warn};
 
@@ -57,13 +56,6 @@ fn main() {
                 .with_components(OdysseyNode::components(&rollup_args))
                 .with_add_ons(OptimismAddOns::new(rollup_args.sequencer_http.clone()))
                 .extend_rpc_modules(move |ctx| {
-                    // register sequencer tx forwarder
-                    if let Some(sequencer_http) = rollup_args.sequencer_http {
-                        ctx.registry
-                            .eth_api()
-                            .set_sequencer_client(SequencerClient::new(sequencer_http))?;
-                    }
-
                     // register odyssey wallet namespace
                     if let Ok(sk) = std::env::var("EXP1_SK") {
                         let signer: PrivateKeySigner =

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -15,7 +15,7 @@ use reth_node_builder::{
         ComponentsBuilder, ExecutorBuilder, NetworkBuilder, PayloadServiceBuilder,
         PoolBuilderConfigOverrides,
     },
-    BuilderContext, Node, NodeTypes,
+    BuilderContext, Node, NodeAdapter, NodeComponentsBuilder, NodeTypes,
 };
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::{
@@ -108,7 +108,9 @@ where
         OptimismEngineValidatorBuilder,
     >;
 
-    type AddOns = OptimismAddOns;
+    type AddOns = OptimismAddOns<
+        NodeAdapter<N, <Self::ComponentsBuilder as NodeComponentsBuilder<N>>::Components>,
+    >;
 
     fn components_builder(&self) -> Self::ComponentsBuilder {
         let Self { args } = self;


### PR DESCRIPTION
smol breaking change on builder API, make the manual sequencer installation redundant