### PR TITLE
fix(e2e): make sure replica receives a block

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,7 +53,8 @@ jobs:
             echo "REPLICA_RPC=http://127.0.0.1:$REPLICA_EL_PORT" >> $GITHUB_ENV
       - name: Run E2E tests
         run: |
+            cast send $(cast az) --private-key "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" --rpc-url $REPLICA_RPC
             cargo nextest run \
-            --locked \
-            --workspace \
-            -E "package(odyssey-e2e-tests)"
+              --locked \
+              --workspace \
+              -E "package(odyssey-e2e-tests)"


### PR DESCRIPTION
Send a simple tx to replica before running tests. This would add it to the pool and await replica receiving a block with this transaction, thus flipping the `prague` fork activation here https://github.com/paradigmxyz/reth/blob/0a1473b6e7949875f480043fa6874bdc583786d2/crates/transaction-pool/src/validate/eth.rs#L467

This is a workaround until we figure out why replica is not able to receive blocks from sequencer over p2p right away after the launch