### PR TITLE
сhore: use upstream kurtosis package

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,8 +43,8 @@ jobs:
             kurtosis engine start
             kurtosis run --enclave op-devnet ./optimism-package --args-file ./etc/kurtosis.yaml
             ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')
-            SEQUENCER_EL_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-1-op-reth-op-node".public_ports.rpc.number')
-            REPLICA_EL_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-2-op-reth-op-node".public_ports.rpc.number')
+            SEQUENCER_EL_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-1-op-reth-op-node-op-kurtosis".public_ports.rpc.number')
+            REPLICA_EL_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-2-op-reth-op-node-op-kurtosis".public_ports.rpc.number')
             echo "SEQUENCER_RPC=http://127.0.0.1:$SEQUENCER_EL_PORT" >> $GITHUB_ENV
             echo "REPLICA_RPC=http://127.0.0.1:$REPLICA_EL_PORT" >> $GITHUB_ENV
       - name: Run E2E tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,16 +34,12 @@ jobs:
             echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
             sudo apt update
             sudo apt install kurtosis-cli
-      - name: Clone optimism-package
-        run: |
-            git clone https://github.com/klkvr/optimism-package
-            cd optimism-package
-            git switch odyssey
       - name: Build Odyssey
         run: docker buildx build . --load -t ghcr.io/ithacaxyz/odyssey:latest
       - name: Run enclave
         id: kurtosis
         run: |
+            git clone https://github.com/klkvr/optimism-package
             kurtosis engine start
             kurtosis run --enclave op-devnet ./optimism-package --args-file ./etc/kurtosis.yaml
             ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')

--- a/etc/kurtosis.yaml
+++ b/etc/kurtosis.yaml
@@ -17,8 +17,8 @@ optimism_package:
         el_image: ghcr.io/ithacaxyz/odyssey:latest
         cl_image: ghcr.io/paradigmxyz/op-node:latest
         el_extra_env_vars:
-          "EXP1_SK": "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba"
-          "EXP1_WHITELIST": "0x0116686E2291dbd5e317F47faDBFb43B599786Ef"
+          EXP1_SK: "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba"
+          EXP1_WHITELIST: "0x0116686E2291dbd5e317F47faDBFb43B599786Ef"
         el_extra_params:
           - "--rollup.discovery.v4"
       network_params:

--- a/etc/kurtosis.yaml
+++ b/etc/kurtosis.yaml
@@ -9,8 +9,8 @@ optimism_package:
         el_image: ghcr.io/ithacaxyz/odyssey:latest
         cl_image: ghcr.io/paradigmxyz/op-node:latest
         el_extra_env_vars:
-          "EXP1_SK": "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba"
-          "EXP1_WHITELIST": "0x0116686E2291dbd5e317F47faDBFb43B599786Ef"
+          EXP1_SK: "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba"
+          EXP1_WHITELIST: "0x0116686E2291dbd5e317F47faDBFb43B599786Ef"
         el_extra_params:
           - "--rollup.discovery.v4"
       - el_type: op-reth

--- a/etc/kurtosis.yaml
+++ b/etc/kurtosis.yaml
@@ -3,10 +3,25 @@ ethereum_package:
     - el_type: reth
       cl_type: lighthouse
 optimism_package:
-  participants:
-    - el_type: op-reth
-      el_image: ghcr.io/ithacaxyz/odyssey:latest
-      count: 2
-  network_params:
-    network_id: "41144114"
-    seconds_per_slot: 1
+  chains:
+    - participants:
+      - el_type: op-reth
+        el_image: ghcr.io/ithacaxyz/odyssey:latest
+        cl_image: ghcr.io/paradigmxyz/op-node:latest
+        el_extra_env_vars:
+          "EXP1_SK": "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba"
+          "EXP1_WHITELIST": "0x0116686E2291dbd5e317F47faDBFb43B599786Ef"
+        el_extra_params:
+          - "--rollup.discovery.v4"
+      - el_type: op-reth
+        el_image: ghcr.io/ithacaxyz/odyssey:latest
+        cl_image: ghcr.io/paradigmxyz/op-node:latest
+        el_extra_env_vars:
+          "EXP1_SK": "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba"
+          "EXP1_WHITELIST": "0x0116686E2291dbd5e317F47faDBFb43B599786Ef"
+        el_extra_params:
+          - "--rollup.discovery.v4"
+      network_params:
+        network_id: "41144114"
+        seconds_per_slot: 1
+        batcher_image: ghcr.io/paradigmxyz/op-batcher:latest


### PR DESCRIPTION
Uses https://github.com/ethpandaops/optimism-package/pull/85 for now, once merged can be replaced with upstream package.

This also switches to using images from https://github.com/paradigmxyz/optimism cc @Rjected 