### PR TITLE
chore: remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4460,7 +4460,6 @@ dependencies = [
  "reth-node-builder",
  "reth-optimism-cli",
  "reth-optimism-node",
- "reth-optimism-rpc",
  "reth-provider",
  "tracing",
 ]
@@ -4506,7 +4505,6 @@ name = "odyssey-precompile"
 version = "0.0.0"
 dependencies = [
  "alloy-primitives",
- "eyre",
  "p256",
  "reth-node-api",
  "reth-primitives",

--- a/bin/odyssey/Cargo.toml
+++ b/bin/odyssey/Cargo.toml
@@ -24,7 +24,6 @@ reth-cli-util.workspace = true
 reth-node-builder.workspace = true
 reth-optimism-node.workspace = true
 reth-optimism-cli.workspace = true
-reth-optimism-rpc.workspace = true
 reth-provider.workspace = true
 clap = { workspace = true, features = ["derive"] }
 

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -19,7 +19,6 @@ p256 = { version = "0.13.2", features = ["ecdsa"] }
 [dev-dependencies]
 reth-node-api.workspace = true
 reth-primitives.workspace = true
-eyre.workspace = true
 rstest.workspace = true
 
 [lints]


### PR DESCRIPTION
Random `cargo machete` run. Also wonder if we're still maintaining `alphanet`?