### PR TITLE
fix: freeze commit for e2e optimism-package

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,9 @@ jobs:
         id: kurtosis
         run: |
             git clone https://github.com/klkvr/optimism-package
+            cd optimism-package
+            git checkout e5a9dc4
+            cd ..
             kurtosis engine start
             kurtosis run --enclave op-devnet ./optimism-package --args-file ./etc/kurtosis.yaml
             ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')


### PR DESCRIPTION
upstream PR is still in review, so locking this for now so that we're not affected by changes applied during review