### PR TITLE
chore: migrate to upstream kurtosis package

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,6 @@ jobs:
             echo "REPLICA_RPC=http://127.0.0.1:$REPLICA_EL_PORT" >> $GITHUB_ENV
       - name: Run E2E tests
         run: |
-            cast send $(cast az) --private-key "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" --rpc-url $REPLICA_RPC
             cargo nextest run \
               --locked \
               --workspace \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,12 +39,8 @@ jobs:
       - name: Run enclave
         id: kurtosis
         run: |
-            git clone https://github.com/klkvr/optimism-package
-            cd optimism-package
-            git checkout e5a9dc4
-            cd ..
             kurtosis engine start
-            kurtosis run --enclave op-devnet ./optimism-package --args-file ./etc/kurtosis.yaml
+            kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package --args-file ./etc/kurtosis.yaml
             ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')
             SEQUENCER_EL_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-1-op-reth-op-node-op-kurtosis".public_ports.rpc.number')
             REPLICA_EL_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-2-op-reth-op-node-op-kurtosis".public_ports.rpc.number')

--- a/README.md
+++ b/README.md
@@ -101,23 +101,10 @@ Running a local network with a full Odyssey OP stack with Kurtosis requires some
 
 To get started, follow [these instructions](https://docs.kurtosis.com/install/) to install Kurtosis.
 
-Next, clone and build the modified `optimism-contract-deployer` image:
+Next, start a Kurtosis enclave:
 
 ```bash
-git clone git@github.com:klkvr/optimism-package.git
-cd optimism-package
-git switch odyssey
-docker build . -t ethpandaops/optimism-contract-deployer:latest --progress plain
-```
-
-> [!NOTE]
->
-> The image may fail to build if you have not allocated enough memory for Docker.
-
-Finally, run start a Kurtosis enclave (ensure you are still in `optimism-package`):
-
-```bash
-kurtosis run --enclave op-devnet github.com/klkvr/optimism-package@odyssey \
+kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package \
   --args-file https://raw.githubusercontent.com/ithacaxyz/odyssey/main/etc/kurtosis.yaml
 ```
 
@@ -127,7 +114,7 @@ This will start an enclave named `op-devnet`. You can tear down the enclave with
 >
 > If you want to use a custom build of Odyssey, simply build an Odyssey image with `docker build . -t ghcr.io/ithacaxyz/odyssey:latest`.
 
-Consult the [Kurtosis OP package](https://github.com/ethpandaops/optimism-package) repository for instructions on how to adjust the args file to spin up additional services, like a block exporer.
+Consult the [Kurtosis OP package](https://github.com/ethpandaops/optimism-package) repository for instructions on how to adjust the args file to spin up additional services, like a block explorer.
 
 ### Wallet extension
 

--- a/etc/kurtosis.yaml
+++ b/etc/kurtosis.yaml
@@ -21,7 +21,8 @@ optimism_package:
           EXP1_WHITELIST: "0x0116686E2291dbd5e317F47faDBFb43B599786Ef"
         el_extra_params:
           - "--rollup.discovery.v4"
+      batcher_params:
+        image: ghcr.io/paradigmxyz/op-batcher:latest
       network_params:
         network_id: "41144114"
         seconds_per_slot: 1
-        batcher_image: ghcr.io/paradigmxyz/op-batcher:latest


### PR DESCRIPTION
Uses https://github.com/ethpandaops/optimism-package directly and updates README a bit as we no more need to build contract deployer image separately

Also removed hack from https://github.com/ithacaxyz/odyssey/pull/52 as it shouldn't be needed after https://github.com/paradigmxyz/reth/pull/11847