### PR TITLE
docs: fix Markdown notice block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Odyssey has 2 goals:
 
 ### Odyssey Testnet
 
-> [!TIP] > [The Odyssey Testnet](https://www.ithaca.xyz/updates/odyssey#odyssey-chapter-1-is-live-on-testnet) is now live on Sepolia and is built with Reth, the OP Stack, and [deployed on Conduit](https://app.conduit.xyz/published/view/odyssey).
+> [!TIP]
+>
+> [The Odyssey Testnet](https://www.ithaca.xyz/updates/odyssey#odyssey-chapter-1-is-live-on-testnet) is now live on Sepolia and is built with Reth, the OP Stack, and [deployed on Conduit](https://app.conduit.xyz/published/view/odyssey).
 
 ### Odyssey Local Development
 


### PR DESCRIPTION
Seems to be rendering incorrectly, see screenshot:

<img width="993" alt="Screenshot 2024-10-23 at 16 38 25" src="https://github.com/user-attachments/assets/6a17f492-4207-4ab4-bec1-8c0722e9afd3">
