### PR TITLE
feat: Remove wallet_getCapabilities

### DIFF
--- a/bin/odyssey/src/main.rs
+++ b/bin/odyssey/src/main.rs
@@ -24,7 +24,6 @@
 //! - `min-trace-logs`: Disables all logs below `trace` level.
 
 use alloy_network::EthereumWallet;
-use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use clap::Parser;
 use eyre::Context;
@@ -71,13 +70,6 @@ fn main() {
                             sk.parse().wrap_err("Invalid EXP0001 secret key.")?;
                         let wallet = EthereumWallet::from(signer);
 
-                        let raw_delegations = std::env::var("EXP1_WHITELIST")
-                            .wrap_err("No EXP0001 delegations specified")?;
-                        let valid_delegations: Vec<Address> = raw_delegations
-                            .split(',')
-                            .map(|addr| Address::parse_checksummed(addr, None))
-                            .collect::<Result<_, _>>()
-                            .wrap_err("No valid EXP0001 delegations specified")?;
 
                         ctx.modules.merge_configured(
                             OdysseyWallet::new(
@@ -85,7 +77,6 @@ fn main() {
                                 wallet,
                                 ctx.registry.eth_api().clone(),
                                 ctx.config().chain.chain().id(),
-                                valid_delegations,
                             )
                             .into_rpc(),
                         )?;

--- a/bin/odyssey/src/main.rs
+++ b/bin/odyssey/src/main.rs
@@ -24,7 +24,6 @@
 //! - `min-trace-logs`: Disables all logs below `trace` level.
 
 use alloy_network::{Ethereum, EthereumWallet, NetworkWallet};
-use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use clap::Parser;
 use eyre::Context;
@@ -91,13 +90,6 @@ fn main() {
 
                     // register odyssey wallet namespace
                     if let Some(wallet) = wallet {
-                        let raw_delegations = std::env::var("EXP1_WHITELIST")
-                            .wrap_err("No EXP0001 delegations specified")?;
-                        let valid_delegations: Vec<Address> = raw_delegations
-                            .split(',')
-                            .map(|addr| Address::parse_checksummed(addr, None))
-                            .collect::<Result<_, _>>()
-                            .wrap_err("No valid EXP0001 delegations specified")?;
 
                         ctx.modules.merge_configured(
                             OdysseyWallet::new(

--- a/bin/odyssey/src/main.rs
+++ b/bin/odyssey/src/main.rs
@@ -90,7 +90,6 @@ fn main() {
 
                     // register odyssey wallet namespace
                     if let Some(wallet) = wallet {
-
                         ctx.modules.merge_configured(
                             OdysseyWallet::new(
                                 ctx.provider().clone(),

--- a/crates/e2e-tests/src/tests.rs
+++ b/crates/e2e-tests/src/tests.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, sync::LazyLock};
+use std::{collections::BTreeMap, str::FromStr, sync::LazyLock};
 
 use alloy::{
     eips::eip7702::Authorization,
@@ -27,6 +27,7 @@ static SEQUENCER_RPC: LazyLock<Url> = LazyLock::new(|| {
         .expect("failed to parse SEQUENCER_RPC env var")
 });
 
+
 #[tokio::test]
 async fn assert_chain_advances() -> Result<(), Box<dyn std::error::Error>> {
     if !ci_info::is_ci() {
@@ -54,8 +55,21 @@ async fn test_wallet_api() -> Result<(), Box<dyn std::error::Error>> {
         "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
     ))?;
 
-    let capabilities: BTreeMap<U256, BTreeMap<String, BTreeMap<String, Vec<Address>>>> =
-        provider.client().request_noparams("wallet_getCapabilities").await?;
+    let capabilities = {
+        let mut innermost_tree = BTreeMap::new();
+        innermost_tree.insert(
+            "addresses".to_string(),
+            vec![Address::from_str(&std::env::var("DELEGATION_ADDRESS").unwrap()).unwrap()],
+        );
+
+        let mut inner_tree = BTreeMap::new();
+        inner_tree.insert("delegation".to_string(), innermost_tree);
+
+        let mut capabilities = BTreeMap::new();
+        capabilities.insert(U256::from(1), inner_tree);
+
+        capabilities
+    };
 
     let chain_id = U256::from(provider.get_chain_id().await?);
 
@@ -98,8 +112,21 @@ async fn test_new_wallet_api() -> Result<(), Box<dyn std::error::Error>> {
         "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
     ))?;
 
-    let capabilities: BTreeMap<U256, BTreeMap<String, BTreeMap<String, Vec<Address>>>> =
-        provider.client().request_noparams("wallet_getCapabilities").await?;
+    let capabilities = {
+        let mut innermost_tree = BTreeMap::new();
+        innermost_tree.insert(
+            "addresses".to_string(),
+            vec![Address::from_str(&std::env::var("DELEGATION_ADDRESS").unwrap()).unwrap()],
+        );
+
+        let mut inner_tree = BTreeMap::new();
+        inner_tree.insert("delegation".to_string(), innermost_tree);
+
+        let mut capabilities = BTreeMap::new();
+        capabilities.insert(U256::from(1), inner_tree);
+
+        capabilities
+    };
 
     let chain_id = U256::from(provider.get_chain_id().await?);
 

--- a/crates/e2e-tests/src/tests.rs
+++ b/crates/e2e-tests/src/tests.rs
@@ -1,8 +1,8 @@
-use std::{collections::BTreeMap, str::FromStr, sync::LazyLock};
+use std::{str::FromStr, sync::LazyLock};
 
 use alloy::{
     eips::eip7702::Authorization,
-    primitives::{b256, Address, B256, U256},
+    primitives::{b256, Address, B256},
     providers::{PendingTransactionBuilder, Provider, ProviderBuilder},
     signers::SignerSync,
 };
@@ -56,7 +56,7 @@ async fn test_wallet_api() -> Result<(), Box<dyn std::error::Error>> {
 
     let delegation_address = Address::from_str(
         &std::env::var("DELEGATION_ADDRESS")
-            .unwrap_or("0x90f79bf6eb2c4f870365e785982e1f101e93b906".to_string()),
+            .unwrap_or_else(|_| "0x90f79bf6eb2c4f870365e785982e1f101e93b906".to_string()),
     )
     .unwrap();
 
@@ -97,7 +97,7 @@ async fn test_new_wallet_api() -> Result<(), Box<dyn std::error::Error>> {
 
     let delegation_address = Address::from_str(
         &std::env::var("DELEGATION_ADDRESS")
-            .unwrap_or("0x90f79bf6eb2c4f870365e785982e1f101e93b906".to_string()),
+            .unwrap_or_else(|_| "0x90f79bf6eb2c4f870365e785982e1f101e93b906".to_string()),
     )
     .unwrap();
 

--- a/crates/e2e-tests/src/tests.rs
+++ b/crates/e2e-tests/src/tests.rs
@@ -27,7 +27,6 @@ static SEQUENCER_RPC: LazyLock<Url> = LazyLock::new(|| {
         .expect("failed to parse SEQUENCER_RPC env var")
 });
 
-
 #[tokio::test]
 async fn assert_chain_advances() -> Result<(), Box<dyn std::error::Error>> {
     if !ci_info::is_ci() {
@@ -55,28 +54,11 @@ async fn test_wallet_api() -> Result<(), Box<dyn std::error::Error>> {
         "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
     ))?;
 
-    let chain_id = U256::from(provider.get_chain_id().await?);
-
-    let capabilities = {
-        let mut innermost_tree = BTreeMap::new();
-        innermost_tree.insert(
-            "addresses".to_string(),
-            vec![Address::from_str(&std::env::var("DELEGATION_ADDRESS").unwrap()).unwrap()],
-        );
-
-        let mut inner_tree = BTreeMap::new();
-        inner_tree.insert("delegation".to_string(), innermost_tree);
-
-        let mut capabilities = BTreeMap::new();
-        capabilities.insert(chain_id, inner_tree);
-
-        capabilities
-    };
-
-
-    let delegation_address =
-        capabilities.get(&chain_id).unwrap().get("delegation").unwrap().get("addresses").unwrap()
-            [0];
+    let delegation_address = Address::from_str(
+        &std::env::var("DELEGATION_ADDRESS")
+            .unwrap_or("0x90f79bf6eb2c4f870365e785982e1f101e93b906".to_string()),
+    )
+    .unwrap();
 
     let auth = Authorization {
         chain_id: provider.get_chain_id().await?,
@@ -113,28 +95,11 @@ async fn test_new_wallet_api() -> Result<(), Box<dyn std::error::Error>> {
         "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
     ))?;
 
-    let chain_id = U256::from(provider.get_chain_id().await?);
-
-    let capabilities = {
-        let mut innermost_tree = BTreeMap::new();
-        innermost_tree.insert(
-            "addresses".to_string(),
-            vec![Address::from_str("0x90f79bf6eb2c4f870365e785982e1f101e93b906").unwrap()],
-            // vec![Address::from_str(&std::env::var("DELEGATION_ADDRESS").unwrap()).unwrap()],
-        );
-
-        let mut inner_tree = BTreeMap::new();
-        inner_tree.insert("delegation".to_string(), innermost_tree);
-
-        let mut capabilities = BTreeMap::new();
-        capabilities.insert(chain_id, inner_tree);
-
-        capabilities
-    };
-
-    let delegation_address =
-        capabilities.get(&chain_id).unwrap().get("delegation").unwrap().get("addresses").unwrap()
-            [0];
+    let delegation_address = Address::from_str(
+        &std::env::var("DELEGATION_ADDRESS")
+            .unwrap_or("0x90f79bf6eb2c4f870365e785982e1f101e93b906".to_string()),
+    )
+    .unwrap();
 
     let auth = Authorization {
         chain_id: provider.get_chain_id().await?,

--- a/crates/e2e-tests/src/tests.rs
+++ b/crates/e2e-tests/src/tests.rs
@@ -55,6 +55,8 @@ async fn test_wallet_api() -> Result<(), Box<dyn std::error::Error>> {
         "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
     ))?;
 
+    let chain_id = U256::from(provider.get_chain_id().await?);
+
     let capabilities = {
         let mut innermost_tree = BTreeMap::new();
         innermost_tree.insert(
@@ -66,12 +68,11 @@ async fn test_wallet_api() -> Result<(), Box<dyn std::error::Error>> {
         inner_tree.insert("delegation".to_string(), innermost_tree);
 
         let mut capabilities = BTreeMap::new();
-        capabilities.insert(U256::from(1), inner_tree);
+        capabilities.insert(chain_id, inner_tree);
 
         capabilities
     };
 
-    let chain_id = U256::from(provider.get_chain_id().await?);
 
     let delegation_address =
         capabilities.get(&chain_id).unwrap().get("delegation").unwrap().get("addresses").unwrap()
@@ -112,23 +113,24 @@ async fn test_new_wallet_api() -> Result<(), Box<dyn std::error::Error>> {
         "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
     ))?;
 
+    let chain_id = U256::from(provider.get_chain_id().await?);
+
     let capabilities = {
         let mut innermost_tree = BTreeMap::new();
         innermost_tree.insert(
             "addresses".to_string(),
-            vec![Address::from_str(&std::env::var("DELEGATION_ADDRESS").unwrap()).unwrap()],
+            vec![Address::from_str("0x90f79bf6eb2c4f870365e785982e1f101e93b906").unwrap()],
+            // vec![Address::from_str(&std::env::var("DELEGATION_ADDRESS").unwrap()).unwrap()],
         );
 
         let mut inner_tree = BTreeMap::new();
         inner_tree.insert("delegation".to_string(), innermost_tree);
 
         let mut capabilities = BTreeMap::new();
-        capabilities.insert(U256::from(1), inner_tree);
+        capabilities.insert(chain_id, inner_tree);
 
         capabilities
     };
-
-    let chain_id = U256::from(provider.get_chain_id().await?);
 
     let delegation_address =
         capabilities.get(&chain_id).unwrap().get("delegation").unwrap().get("addresses").unwrap()

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! Implementations of a custom `wallet_` namespace for Odyssey experiment 1.
 //!
-//! - `wallet_getCapabilities` based on [EIP-5792][eip-5792], with the only capability being
-//!   `delegation`.
 //! - `odyssey_sendTransaction` that can perform sequencer-sponsored [EIP-7702][eip-7702]
 //!   delegations and send other sequencer-sponsored transactions on behalf of EOAs with delegated
 //!   code.

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -76,16 +76,6 @@ impl WalletCapabilities {
 #[cfg_attr(not(test), rpc(server, namespace = "wallet"))]
 #[cfg_attr(test, rpc(server, client, namespace = "wallet"))]
 pub trait OdysseyWalletApi {
-    /// Get the capabilities of the wallet.
-    ///
-    /// Currently the only capability is [`DelegationCapability`].
-    ///
-    /// See also [EIP-5792][eip-5792].
-    ///
-    /// [eip-5792]: https://eips.ethereum.org/EIPS/eip-5792
-    #[method(name = "getCapabilities")]
-    fn get_capabilities(&self) -> RpcResult<WalletCapabilities>;
-
     /// Send a sequencer-sponsored transaction.
     ///
     /// The transaction will only be processed if:
@@ -200,10 +190,6 @@ where
     Provider: StateProviderFactory + Send + Sync + 'static,
     Eth: FullEthApi + Send + Sync + 'static,
 {
-    fn get_capabilities(&self) -> RpcResult<WalletCapabilities> {
-        trace!(target: "rpc::wallet", "Serving wallet_getCapabilities");
-        Ok(self.inner.capabilities.clone())
-    }
 
     async fn send_transaction(&self, mut request: TransactionRequest) -> RpcResult<TxHash> {
         trace!(target: "rpc::wallet", ?request, "Serving odyssey_sendTransaction");

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -23,7 +23,7 @@ use alloy_eips::BlockId;
 use alloy_network::{
     eip2718::Encodable2718, Ethereum, EthereumWallet, NetworkWallet, TransactionBuilder,
 };
-use alloy_primitives::{map::HashMap, Address, ChainId, TxHash, TxKind, U256, U64};
+use alloy_primitives::{Address, ChainId, TxHash, TxKind, U256};
 use alloy_rpc_types::TransactionRequest;
 use jsonrpsee::{
     core::{async_trait, RpcResult},
@@ -143,7 +143,6 @@ impl<Provider, Eth> OdysseyWallet<Provider, Eth> {
         wallet: EthereumWallet,
         eth_api: Eth,
         chain_id: ChainId,
-        valid_designations: Vec<Address>,
     ) -> Self {
         let inner = OdysseyWalletInner {
             provider,
@@ -327,8 +326,8 @@ struct WalletMetrics {
 
 #[cfg(test)]
 mod tests {
-    use crate::{validate_tx_request, DelegationCapability, OdysseyWalletError};
-    use alloy_primitives::{address, map::HashMap, Address, U256, U64};
+    use crate::{validate_tx_request, OdysseyWalletError};
+    use alloy_primitives::{Address, U256};
     use alloy_rpc_types::TransactionRequest;
     #[test]
     fn no_value_allowed() {


### PR DESCRIPTION
Closes #99 


Removed `get_capabilities` from the `WalletCapabilities` trait
In `e2e_tests` the capabilities is initialised manually with the contract address being pulled in from `env` variables.


Related PR: https://github.com/ithacaxyz/odyssey/pull/104#pullrequestreview-2479776747
