### PR TITLE
ci: use exact nextext filter

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,5 +2,5 @@
 serial-integration = { max-threads = 1 }
 
 [[profile.default.overrides]]
-filter = 'package(odyssey-e2e-tests)'
+filter = 'package(=odyssey-e2e-tests)'
 test-group = 'serial-integration'


### PR DESCRIPTION
- Providing a more specific package reference prevents potential conflicts if packages with similar names emerge.
- This aligns with the current recommendations in the Nextest documentation.
- It improves the readability of the configuration for other developers.