### PR TITLE
docs,fix: Improve error output and documentation clarity in relay ser…

### DIFF
--- a/bin/relay/src/main.rs
+++ b/bin/relay/src/main.rs
@@ -1,6 +1,6 @@
 //! # Odyssey Relay
 //!
-//! TBD
+//! A relay service that sponsors transactions for EIP-7702 accounts.
 
 use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder};
 use alloy_rpc_client::RpcClient;
@@ -25,6 +25,7 @@ struct Args {
     #[arg(long = "http.port", value_name = "PORT", default_value_t = 9119)]
     port: u16,
     /// The RPC endpoint of the chain to send transactions to.
+    /// Must be a valid HTTP or HTTPS URL pointing to an Ethereum JSON-RPC endpoint.
     #[arg(long, value_name = "RPC_ENDPOINT")]
     upstream: Url,
     /// The secret key to sponsor transactions with.
@@ -71,7 +72,7 @@ async fn main() {
 
     let args = Args::parse();
     if let Err(err) = args.run().await {
-        eprint!("Error: {err:?}");
+        eprintln!("Error: {err:?}");
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
### Changes
This PR includes several improvements to the relay service:

1. Changed `eprint!` to `eprintln!` for error output to ensure proper line breaks in terminal output
2. Replaced placeholder "TBD" documentation with actual service description
3. Enhanced RPC endpoint documentation with URL requirements

### Motivation
These changes improve developer experience by:
- Making error messages more readable in the terminal
- Providing clear and accurate documentation about the service's purpose
- Adding specific requirements for the RPC endpoint configuration

### Impact
These changes are non-functional improvements that only affect documentation and error output formatting. No behavioral changes are introduced.