### PR TITLE
feat: added P256Verify precompile to 0x100

### DIFF
--- a/crates/node/src/evm.rs
+++ b/crates/node/src/evm.rs
@@ -357,7 +357,8 @@ mod tests {
             .append_handler_register(OdysseyEvmConfig::set_precompiles)
             .build();
 
-        let precompiles = evm.context.evm.precompiles;
+        // loading the precompiles from pre execution instead of the evm context directly, as they are only set pre-execution in the context
+        let precompiles = evm.handler.pre_execution().load_precompiles();
         assert!(precompiles.contains(&u64_to_address(0x14)));
         assert!(precompiles.contains(&u64_to_address(0x100)));
     }

--- a/crates/node/src/evm.rs
+++ b/crates/node/src/evm.rs
@@ -358,7 +358,7 @@ mod tests {
             .build();
 
         let precompiles = evm.context.evm.precompiles;
-        assert!(precompiles.contains(P256VERIFY.address()));
-        assert!(precompiles.contains(REVM_P256VERIFY.address()));
+        assert!(precompiles.contains(&u64_to_address(0x14)));
+        assert!(precompiles.contains(&u64_to_address(0x100)));
     }
 }

--- a/crates/node/src/evm.rs
+++ b/crates/node/src/evm.rs
@@ -29,7 +29,10 @@ use reth_revm::{
     },
     ContextPrecompiles, Database, Evm, EvmBuilder, GetInspector,
 };
-use revm_precompile::{secp256r1::p256_verify, u64_to_address, PrecompileWithAddress};
+use revm_precompile::{
+    secp256r1::{p256_verify, P256VERIFY as REVM_P256VERIFY},
+    u64_to_address, PrecompileWithAddress,
+};
 use revm_primitives::{CfgEnvWithHandlerCfg, Precompile, TxEnv};
 use std::sync::Arc;
 
@@ -53,7 +56,7 @@ impl OdysseyEvmConfig {
     }
 
     fn precompiles() -> impl Iterator<Item = PrecompileWithAddress> {
-        [P256VERIFY].into_iter()
+        [P256VERIFY, REVM_P256VERIFY].into_iter()
     }
 
     /// Sets the precompiles to the EVM handler
@@ -343,5 +346,19 @@ mod tests {
         );
 
         assert_eq!(cfg_env.chain_id, chain_spec.chain().id());
+    }
+
+    #[test]
+    fn test_p256verify_precompile_availability() {
+        let evm = EvmBuilder::default()
+            .with_empty_db()
+            .optimism()
+            // add additional precompiles
+            .append_handler_register(OdysseyEvmConfig::set_precompiles)
+            .build();
+
+        let precompiles = evm.context.evm.precompiles;
+        assert!(precompiles.contains(P256VERIFY.address()));
+        assert!(precompiles.contains(REVM_P256VERIFY.address()));
     }
 }


### PR DESCRIPTION
Closes #125 

Added `P256Verify` precompile to the `0x100` address and a test to check its availability at both the addresses

The test is currently failing, and I'm not entirely sure about my implementation of test function. It might be causing the test to fail. 

lmk of any suggestions @onbjerg 