### PR TITLE
chore: Fix transaction rebroadcast interval to match intended 10-m delay

### DIFF
--- a/crates/node/src/broadcaster.rs
+++ b/crates/node/src/broadcaster.rs
@@ -18,7 +18,7 @@ pub async fn periodic_broadcaster<P, N>(
     P: TransactionPool,
     N: NetworkPrimitives,
 {
-    let mut interval_timer = tokio::time::interval(Duration::from_secs(60));
+    let mut interval_timer = tokio::time::interval(Duration::from_secs(600));
 
     loop {
         let transactions =


### PR DESCRIPTION
I noticed a discrepancy in the timer interval for transaction rebroadcasting. The code currently sets the interval to 60 seconds (1 minute), but the comment above clearly states that transactions should be rebroadcast every 10 minutes. I've updated the value to `600` seconds to align with the intended behavior.  

Here's the corrected line:  
```rust  
let mut interval_timer = tokio::time::interval(Duration::from_secs(600));  
```  

This change ensures the functionality matches the documented logic.