### PR TITLE
fix(ci): use prysm and fix proof window command

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,6 +50,9 @@ jobs:
           REPLICA_EL_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-2-op-reth-op-node-op-kurtosis".public_ports.rpc.number')
           echo "SEQUENCER_RPC=http://127.0.0.1:$SEQUENCER_EL_PORT" >> $GITHUB_ENV
           echo "REPLICA_RPC=http://127.0.0.1:$REPLICA_EL_PORT" >> $GITHUB_ENV
+      - name: Wait for pectra
+        run: |
+          while true; do sleep 5; current_head=$(cast bn --rpc-url=$REPLICA_RPC); echo "L1 Execution is starting up, head is $current_head"; if [ "$current_head" -ge "32" ]; then echo "L1 Execution is post-pectra!"; break; fi; done
       - name: Run E2E tests
         run: |
           cargo nextest run \

--- a/etc/kurtosis.yaml
+++ b/etc/kurtosis.yaml
@@ -2,8 +2,23 @@ ethereum_package:
   participants:
     - el_type: reth
       el_extra_params:
-        - "--rpc.eth-proof-window 100"
+        - "--rpc.eth-proof-window=100"
       cl_type: lighthouse
+      cl_image: sigp/lighthouse:v7.0.0-beta.0
+
+  network_params:
+    seconds_per_slot: 1
+    deneb_fork_epoch: 0
+    electra_fork_epoch: 1
+    additional_preloaded_contracts: |
+      {
+        "0x4e59b44847b379578588920cA78FbF26c0B4956C": {
+          "balance": "0ETH",
+          "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3",
+          "storage": {},
+          "nonce": "1"
+        }
+      }
 optimism_package:
   chains:
     - participants:


### PR DESCRIPTION
Fixes error in the kurtosis e2e tests: 

```
  Caused by: Unexpected error occurred starting service 'el-1-reth-lighthouse'
  Caused by: An error occurred waiting for all TCP and UDP ports to be open for service 'el-1-reth-lighthouse' with private IP '172.16.0.10'; this is usually due to a misconfiguration in the service itself, so here are the logs:
  == SERVICE 'el-1-reth-lighthouse' LOGS ===================================
  error: unexpected argument '--rpc.eth-proof-window 100' found
  
    tip: a similar argument exists: '--rpc.eth-proof-window'
```


Transitions to pectra instead of setting at genesis because currently kurtosis does not appear to work when enabling electra at genesis. The deterministic deployer has to be set at genesis, so it's added as a predeploy. This also waits for block 32, then runs the odyssey e2e tests, and uses a pectra-compatible lighthouse image.