### PR TITLE
fix: fix panic when `get_code_at` returns `None`

### DIFF
--- a/crates/e2e-tests/src/tests.rs
+++ b/crates/e2e-tests/src/tests.rs
@@ -95,7 +95,7 @@ async fn test_wallet_api() -> Result<(), Box<dyn std::error::Error>> {
     let receipt = PendingTransactionBuilder::new(provider.clone(), tx_hash).get_receipt().await?;
 
     assert!(receipt.status(), "Transaction failed");
-    assert!(!provider.get_code_at(signer.address()).await?.is_empty(), "No code at signer address");
+    assert!(!provider.get_code_at(signer.address()).await?.unwrap_or_default().is_empty(), "No code at signer address");
 
     Ok(())
 }


### PR DESCRIPTION
Noticed that `get_code_at(signer.address())` can return `None`, which causes a panic when calling `.is_empty()`.
Now using `unwrap_or_default()` to prevent this issue.

P.S. Everything works fine, and tests pass.