### PR TITLE
docs: update link RIP-7212 in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Odyssey implements traits provided by the [reth node builder API](https://paradi
 Specifically, Odyssey currently implements the following EIPs:
 
 - [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702): Set EOA account code.
-- [RIP-7212](https://ethereum-magicians.org/t/eip-7212-precompiled-for-secp256r1-curve-support/14789): Precompile for secp256r1 curve support.
+- [RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md): Precompile for secp256r1 curve support.
 - [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537): Precompiles for BLS12-381 curve operations.
 
 Odyssey also implements the EIPs for EOF, or [The EVM Object Format](https://evmobjectformat.org/).


### PR DESCRIPTION
Hi! I updated the link for `RIP-7212` in README.md because the new link provides more specific and up-to-date information about `RIP-7212`. This change will help developers find the necessary details more quickly and also allow them, if needed, to navigate to the forum or other resources directly from this [page](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md).
![image](https://github.com/user-attachments/assets/b95be33b-159e-4b7b-bc6d-472e2288aefd)
