### PR TITLE
chore: fix incorrect reference to EIP-5792

### DIFF
--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -11,7 +11,6 @@
 //! rudimentary abuse of the service's funds. For example, transactions cannot contain any
 //! `value`.
 //!
-//! [eip-5792]: https://eips.ethereum.org/EIPS/eip-5792
 //! [eip-7702]: https://eips.ethereum.org/EIPS/eip-7702
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]


### PR DESCRIPTION
Noticed that the reference to [eip-5792] doesn’t match the context—only EIP-7702 is mentioned in the documentation. It seems like a mistake, so I’ve removed the link. If EIP-5792 is actually relevant, it might need to be added to the text explicitly instead.