### PR TITLE
Fix build error

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -180,13 +180,13 @@ where
         > + Unpin
         + 'static,
 {
-    type Primitives = OpNetworkPrimitives;
+    type Network = NetworkHandle<OpNetworkPrimitives>;
 
     async fn build_network(
         self,
         ctx: &BuilderContext<Node>,
         pool: Pool,
-    ) -> eyre::Result<NetworkHandle<Self::Primitives>> {
+    ) -> eyre::Result<Self::Network> {
         let mut network_config = self.inner.network_config(ctx)?;
         // this is rolled with limited trusted peers, and we want to ignore any reputation slashing
         network_config.peers_config.reputation_weights = ReputationChangeWeights::zero();
@@ -202,7 +202,7 @@ where
             ..network_config.transactions_manager_config.clone()
         };
         let network = NetworkManager::<OpNetworkPrimitives>::builder(network_config).await?;
-        let handle =
+        let handle: NetworkHandle<OpNetworkPrimitives> =
             ctx.start_network_with(network, pool, tx_config, TransactionPropagationKind::default());
         info!(target: "reth::cli", enode=%handle.local_node_record(), "P2P networking initialized");
         Ok(handle)


### PR DESCRIPTION
This PR fixes the following build error
```
error[E0437]: type `Primitives` is not a member of trait `NetworkBuilder`
   --> crates/node/src/node.rs:183:5
    |
183 |     type Primitives = OpNetworkPrimitives;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `NetworkBuilder`

error[E0220]: associated type `Primitives` not found for `Self`
   --> crates/node/src/node.rs:189:43
    |
189 |     ) -> eyre::Result<NetworkHandle<Self::Primitives>> {
    |                                           ^^^^^^^^^^ help: `Self` has the following associated type: `Network`

error[E0046]: not all trait items implemented, missing: `Network`
   --> crates/node/src/node.rs:172:1
    |
172 | / impl<Node, Pool> NetworkBuilder<Node, Pool> for OdysseyNetworkBuilder
173 | | where
174 | |     Node: FullNodeTypes<Types: NodeTypes<ChainSpec = OpChainSpec, Primitives = OpPrimitives>>,
175 | |     Pool: TransactionPool<
...   |
180 | |         > + Unpin
181 | |         + 'static,
    | |__________________^ missing `Network` in implementation
    |
    = help: implement the missing item: `type Network = /* Type */;`

Some errors have detailed explanations: E0046, E0220, E0437.
For more information about an error, try `rustc --explain E0046`.
error: could not compile `odyssey-node` (lib) due to 3 previous errors
```