### PR TITLE
Update repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,4 +168,4 @@ shall be dual licensed as above, without any additional terms or conditions.
 [apache-url]: LICENSE-APACHE
 [actions-badge]: https://github.com/ithacaxyz/odyssey/workflows/unit/badge.svg
 [actions-url]: https://github.com/ithacaxyz/odyssey/actions?query=workflow%3ACI+branch%3Amain
-[foundry-odyssey]: https://github.com/ithacaxyz/foundry-odyssey
+[foundry-odyssey]: https://github.com/ithacaxyz/odyssey


### PR DESCRIPTION
Hey !
I changed the link from `https://github.com/ithacaxyz/foundry-odyssey` to `https://github.com/ithacaxyz/odyssey` because the old repository is no longer maintained. Should we also rename the reference tag `[foundry-odyssey]` to `[odyssey]` to keep things consistent?
