### PR TITLE
fix(webpki): replace dead issue link with LICENSE reference

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -29,7 +29,7 @@ allow = [
     "MPL-2.0",
     # https://github.com/briansmith/ring/issues/902
     "LicenseRef-ring",
-    # https://github.com/briansmith/webpki/issues/148
+    # https://github.com/briansmith/webpki/blob/main/LICENSE
     "LicenseRef-webpki",
 ]
 


### PR DESCRIPTION


Old: https://github.com/briansmith/webpki/issues/148

New: https://github.com/briansmith/webpki/blob/main/LICENSE

This update ensures the LicenseRef-webpki points to a valid and persistent license source instead of a non-existent issue. The old issue has been removed from the repository, and no open alternatives exist.

If there's a better canonical reference you recommend for this license, please share it — happy to update accordingly.