### PR TITLE
chore: migrate crates/node to use reth-op meta-crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5083,6 +5083,7 @@ dependencies = [
  "odyssey-walltime",
  "reth-cli-util",
  "reth-node-builder",
+ "reth-op",
  "reth-optimism-cli",
  "reth-optimism-node",
  "reth-provider",
@@ -5129,23 +5130,15 @@ dependencies = [
  "op-alloy-consensus",
  "parking_lot",
  "reth-chain-state",
- "reth-chainspec",
  "reth-cli",
  "reth-errors",
- "reth-network",
  "reth-network-types",
- "reth-node-api",
- "reth-node-builder",
- "reth-optimism-chainspec",
+ "reth-op",
  "reth-optimism-forks",
- "reth-optimism-node",
  "reth-optimism-payload-builder",
- "reth-optimism-primitives",
  "reth-optimism-rpc",
- "reth-primitives-traits",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
- "reth-transaction-pool",
  "reth-trie-common",
  "reth-trie-db",
  "serde",
@@ -6113,7 +6106,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6137,7 +6130,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6166,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6186,7 +6179,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6200,7 +6193,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "ahash",
  "alloy-chains",
@@ -6271,7 +6264,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6281,7 +6274,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6299,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6317,7 +6310,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -6328,7 +6321,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6343,7 +6336,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6356,7 +6349,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6368,7 +6361,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6392,7 +6385,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -6416,7 +6409,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6442,7 +6435,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6471,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6485,7 +6478,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6511,7 +6504,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6535,7 +6528,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6559,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6589,7 +6582,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -6620,7 +6613,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6644,7 +6637,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6669,7 +6662,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "futures",
  "pin-project",
@@ -6692,7 +6685,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6739,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -6766,7 +6759,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6782,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -6797,7 +6790,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -6817,7 +6810,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -6828,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6856,7 +6849,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6877,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6895,7 +6888,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -6908,7 +6901,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6925,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -6935,7 +6928,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6958,7 +6951,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6976,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -6989,7 +6982,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7007,7 +7000,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7045,7 +7038,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7059,7 +7052,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "serde",
  "serde_json",
@@ -7069,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7097,7 +7090,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "bytes",
  "futures",
@@ -7117,7 +7110,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "bitflags 2.9.0",
  "byteorder",
@@ -7134,7 +7127,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "bindgen",
  "cc",
@@ -7143,7 +7136,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "futures",
  "metrics",
@@ -7155,7 +7148,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
 ]
@@ -7163,7 +7156,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7177,7 +7170,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7232,7 +7225,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -7255,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7277,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7292,7 +7285,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -7306,7 +7299,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7323,7 +7316,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -7347,7 +7340,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7412,7 +7405,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7463,7 +7456,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7487,7 +7480,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "eyre",
  "http",
@@ -7507,7 +7500,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -7518,9 +7511,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-op"
+version = "1.4.8"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
+dependencies = [
+ "reth-chainspec",
+ "reth-cli-util",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-db",
+ "reth-eth-wire",
+ "reth-evm",
+ "reth-network",
+ "reth-network-api",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-optimism-chainspec",
+ "reth-optimism-cli",
+ "reth-optimism-consensus",
+ "reth-optimism-evm",
+ "reth-optimism-node",
+ "reth-optimism-primitives",
+ "reth-optimism-rpc",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc",
+ "reth-rpc-api",
+ "reth-rpc-builder",
+ "reth-rpc-eth-types",
+ "reth-storage-api",
+ "reth-tasks",
+ "reth-transaction-pool",
+ "reth-trie",
+]
+
+[[package]]
 name = "reth-optimism-chainspec"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7547,7 +7577,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-cli"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7594,7 +7624,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-consensus"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7619,7 +7649,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-evm"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7644,7 +7674,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-forks"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -7655,7 +7685,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-node"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7702,7 +7732,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-payload-builder"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7741,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7760,7 +7790,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-rpc"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7818,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-storage"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7834,7 +7864,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-txpool"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7870,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types",
@@ -7890,7 +7920,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -7902,7 +7932,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7921,7 +7951,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7931,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7941,7 +7971,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7970,7 +8000,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8012,7 +8042,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8040,7 +8070,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8053,7 +8083,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8066,7 +8096,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8142,7 +8172,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -8170,7 +8200,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8208,7 +8238,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8238,7 +8268,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8281,7 +8311,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8323,7 +8353,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -8337,7 +8367,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8353,7 +8383,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types-compat"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -8375,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8421,7 +8451,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8448,7 +8478,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8461,7 +8491,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -8481,7 +8511,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -8493,7 +8523,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8517,7 +8547,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8533,7 +8563,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -8551,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -8561,7 +8591,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "clap",
  "eyre",
@@ -8576,7 +8606,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8614,7 +8644,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8638,7 +8668,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8661,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -8674,7 +8704,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8699,7 +8729,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8717,7 +8747,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#af912c41f35954fc5ff99e7757f03b33d43a62a3"
+source = "git+https://github.com/paradigmxyz/reth.git#a9bbc9be6551f2c6359ee8a36607aae6591a266e"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,6 @@ alloy = { version = "1.0.9", features = [
     "signers",
     "reqwest-rustls-tls",
 ], default-features = false }
-alloy-consensus = { version = "1.0.9", default-features = false }
 alloy-eips = { version = "1.0.9", default-features = false }
 alloy-network = { version = "1.0.9", default-features = false }
 alloy-provider = { version = "1.0.9", default-features = false }
@@ -159,30 +158,20 @@ alloy-json-rpc = { version = "1.0.9", default-features = false }
 alloy-rpc-types-eth = { version = "1.0.9", default-features = false }
 alloy-rpc-types-engine = { version = "1.0.9", default-features = false }
 alloy-signer-local = { version = "1.0.9", features = ["mnemonic"] }
-alloy-transport = { version = "1.0.9", default-features = false }
-alloy-transport-http = { version = "1.0.9", default-features = false, features = [
-    "reqwest",
-    "reqwest-rustls-tls",
-] }
 alloy-primitives = { version = "1.1.0", default-features = false }
-
-reqwest = { version = "0.12.9", default-features = false, features = [
-    "rustls-tls",
-] }
 
 # tokio
 tokio = { version = "1.21", default-features = false }
 
-# Updated to Reth 1.4.8
-reth = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
+reth-op = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
+
+# Individual reth crates still needed (not included in reth-op)
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-cli = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-errors = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-optimism-node = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
@@ -193,12 +182,9 @@ reth-optimism-payload-builder = { git = "https://github.com/paradigmxyz/reth.git
 reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-trie-db = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-storage-api = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
@@ -206,24 +192,8 @@ reth-network = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4
 reth-network-types = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 reth-chain-state = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
 
-# alloy-evm - updated to match Reth 1.4.8
-alloy-evm = { version = "0.10", default-features = false }
-alloy-op-evm = { version = "0.10", default-features = false }
-
-# revm-optimism - updated to match Reth 1.4.8
-op-revm = { version = "5.0.0", default-features = false }
-
 # op-alloy - updated to match Reth 1.4.8
 op-alloy-consensus = { version = "0.17.2", default-features = false }
-op-alloy-rpc-types = { version = "0.17.2", default-features = false }
-op-alloy-network = { version = "0.17.2", default-features = false }
-
-# Updated revm to match Reth 1.4.8
-revm = { version = "24.0.1", default-features = false }
-revm-primitives = { version = "19.0.0" }
-revm-interpreter = { version = "20.0.0", default-features = false }
-revm-precompile = { version = "22.0.0", default-features = false, features = ["secp256r1"] }
-revm-inspectors = { version = "0.23.0", default-features = false }
 
 # metrics
 metrics = "0.24.0"
@@ -246,8 +216,6 @@ futures = "0.3"
 url = "2.5"
 parking_lot = "0.12"
 
-# misc-testing
-rstest = "0.18.2"
 
 ## TODO(dan): remove this when reth removes
 #[patch.crates-io]

--- a/bin/odyssey/Cargo.toml
+++ b/bin/odyssey/Cargo.toml
@@ -20,11 +20,12 @@ odyssey-wallet.workspace = true
 odyssey-walltime.workspace = true
 eyre.workspace = true
 tracing.workspace = true
+reth-op = { workspace = true, features = ["node", "cli"] }
 reth-cli-util.workspace = true
 reth-node-builder.workspace = true
+reth-provider.workspace = true
 reth-optimism-node = { workspace = true, features = ["js-tracer"] }
 reth-optimism-cli.workspace = true
-reth-provider.workspace = true
 
 [features]
 default = ["jemalloc"]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -12,25 +12,20 @@ categories.workspace = true
 [dependencies]
 odyssey-common.workspace = true
 
-reth-primitives-traits.workspace = true
+# Use reth-op with full and cli features to reduce individual dependencies
+reth-op = { workspace = true, features = ["full", "cli"] }
+
+# These still need to be imported separately as they're not fully re-exported by reth-op
 reth-cli.workspace = true
 reth-errors.workspace = true
-reth-node-api.workspace = true
-reth-node-builder.workspace = true
-reth-optimism-node.workspace = true
-reth-optimism-forks.workspace = true
-reth-optimism-chainspec.workspace = true
-reth-optimism-primitives.workspace = true
-reth-optimism-payload-builder.workspace = true
-reth-optimism-rpc.workspace = true
-reth-chainspec.workspace = true
 reth-rpc-eth-api.workspace = true
 reth-rpc-eth-types.workspace = true
-reth-transaction-pool.workspace = true
 reth-trie-common.workspace = true
 reth-trie-db.workspace = true
-reth-network.workspace = true
+reth-optimism-forks.workspace = true
 reth-network-types.workspace = true
+reth-optimism-payload-builder.workspace = true
+reth-optimism-rpc.workspace = true
 reth-chain-state.workspace = true
 
 alloy-eips.workspace = true

--- a/crates/node/src/broadcaster.rs
+++ b/crates/node/src/broadcaster.rs
@@ -1,8 +1,10 @@
 //! Sponsor periodic broadcaster
 
 use alloy_primitives::Address;
-use reth_network::{transactions::TransactionsHandle, NetworkPrimitives};
-use reth_transaction_pool::TransactionPool;
+use reth_op::{
+    network::{transactions::TransactionsHandle, NetworkPrimitives},
+    pool::TransactionPool,
+};
 use std::time::Duration;
 
 /// Periodically broadcasts sponsored transactions from the transaction pool.

--- a/crates/node/src/chainspec.rs
+++ b/crates/node/src/chainspec.rs
@@ -1,13 +1,15 @@
 //! Odyssey chainspec parsing logic.
 use alloy_primitives::U256;
-use reth_chainspec::{
-    BaseFeeParams, BaseFeeParamsKind, Chain, ChainHardforks, ChainSpec, EthereumHardfork,
-    ForkCondition, Hardfork, NamedChain,
+use reth_op::{
+    chainspec::{
+        make_op_genesis_header, BaseFeeParams, BaseFeeParamsKind, Chain, ChainHardforks, ChainSpec,
+        EthereumHardfork, ForkCondition, Hardfork, NamedChain, OpChainSpec,
+    },
+    primitives::SealedHeader,
 };
+// OpHardfork needs to be imported directly
 use reth_cli::chainspec::{parse_genesis, ChainSpecParser};
-use reth_optimism_chainspec::{make_op_genesis_header, OpChainSpec};
 use reth_optimism_forks::OpHardfork;
-use reth_primitives_traits::SealedHeader;
 use std::sync::{Arc, LazyLock};
 
 /// Odyssey forks.
@@ -111,8 +113,8 @@ mod tests {
     use std::path::PathBuf;
 
     use super::OdysseyChainSpecParser;
-    use reth_chainspec::EthereumHardforks;
     use reth_cli::chainspec::ChainSpecParser;
+    use reth_op::chainspec::EthereumHardforks;
     use reth_optimism_forks::OpHardforks;
 
     #[test]

--- a/crates/node/src/delayed_resolve.rs
+++ b/crates/node/src/delayed_resolve.rs
@@ -8,7 +8,7 @@ use jsonrpsee::{
 };
 use parking_lot::Mutex;
 use reth_chain_state::CanonStateNotification;
-use reth_optimism_primitives::OpPrimitives;
+use reth_op::OpPrimitives;
 use serde::de::Error;
 use serde_json::value::RawValue;
 use std::{

--- a/crates/node/src/forwarder.rs
+++ b/crates/node/src/forwarder.rs
@@ -2,8 +2,10 @@
 
 use alloy_eips::eip2718::Decodable2718;
 use alloy_primitives::Bytes;
-use reth_network::{transactions::TransactionsHandle, NetworkPrimitives};
-use reth_primitives_traits::transaction::signed::SignedTransaction;
+use reth_op::{
+    network::{transactions::TransactionsHandle, NetworkPrimitives},
+    primitives::transaction::signed::SignedTransaction,
+};
 use tokio::sync::broadcast::Receiver;
 use tracing::trace;
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -3,7 +3,7 @@
 //! This contains mainly the [`OdysseyNode`](node::OdysseyNode) type.
 //!
 //! The [`OdysseyNode`](node::OdysseyNode) type implements the
-//! [`NodeTypes`](reth_node_builder::NodeTypes) trait, and configures the engine types required for
+//! [`NodeTypes`](reth_op::node::builder::NodeTypes) trait, and configures the engine types required for
 //! the optimism engine API.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -3,8 +3,8 @@
 //! This contains mainly the [`OdysseyNode`](node::OdysseyNode) type.
 //!
 //! The [`OdysseyNode`](node::OdysseyNode) type implements the
-//! [`NodeTypes`](reth_op::node::builder::NodeTypes) trait, and configures the engine types required for
-//! the optimism engine API.
+//! [`NodeTypes`](reth_op::node::builder::NodeTypes) trait, and configures the engine types required
+//! for the optimism engine API.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![warn(unused_crate_dependencies)]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -4,36 +4,38 @@
 //! required for the optimism engine API.
 
 use op_alloy_consensus::OpPooledTransaction;
-use reth_network::{
-    transactions::{
-        config::TransactionPropagationKind, TransactionPropagationMode, TransactionsManagerConfig,
-    },
-    NetworkHandle, NetworkManager, PeersInfo,
-};
 use reth_network_types::ReputationChangeWeights;
-use reth_node_api::{FullNodeTypes, TxTy};
-use reth_node_builder::{
-    components::{
-        BasicPayloadServiceBuilder, ComponentsBuilder, NetworkBuilder, PoolBuilderConfigOverrides,
+use reth_op::{
+    chainspec::OpChainSpec,
+    network::{
+        transactions::{
+            config::TransactionPropagationKind, TransactionPropagationMode,
+            TransactionsManagerConfig,
+        },
+        NetworkHandle, NetworkManager, PeersInfo,
     },
-    BuilderContext, Node, NodeAdapter, NodeComponentsBuilder, NodeTypes,
-};
-use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_node::{
-    args::RollupArgs,
     node::{
-        OpAddOns, OpConsensusBuilder, OpExecutorBuilder, OpNetworkBuilder, OpPayloadBuilder,
-        OpPoolBuilder,
+        api::{FullNodeTypes, TxTy},
+        args::RollupArgs,
+        builder::{
+            components::{
+                BasicPayloadServiceBuilder, ComponentsBuilder, NetworkBuilder,
+                PoolBuilderConfigOverrides,
+            },
+            BuilderContext, Node, NodeAdapter, NodeComponentsBuilder, NodeTypes,
+        },
+        node::{
+            OpAddOns, OpConsensusBuilder, OpExecutorBuilder, OpNetworkBuilder, OpPayloadBuilder,
+            OpPoolBuilder,
+        },
+        rpc::OpEngineApiBuilder,
+        OpEngineTypes, OpEngineValidatorBuilder, OpNetworkPrimitives, OpStorage,
     },
-    rpc::OpEngineApiBuilder,
-    OpEngineTypes, OpEngineValidatorBuilder, OpNetworkPrimitives, OpStorage,
+    pool::{PoolTransaction, SubPoolLimit, TransactionPool, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER},
+    OpPrimitives,
 };
 use reth_optimism_payload_builder::config::OpDAConfig;
-use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_rpc::eth::OpEthApiBuilder;
-use reth_transaction_pool::{
-    PoolTransaction, SubPoolLimit, TransactionPool, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
-};
 use reth_trie_db::MerklePatriciaTrie;
 use std::time::Duration;
 use tracing::info;

--- a/crates/walltime/Cargo.toml
+++ b/crates/walltime/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
-reth-chain-state.workspace = true
 reth-optimism-primitives.workspace = true
+reth-chain-state.workspace = true
 
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
> The Cargo.toml file has a lot of reth dependencies, reth recently added the reth-op crate which re-exports all of the crates behind feature flags. Try to transition the dependencies of the crates in this workspace to reth-op enabling the necessary features (node or full and cli). Similar migrations have been made to the crates in the reth repository's examples folder, which can be a helpful reference for this task.
> 
> In addition to that remove unused dependencies from this workspace dependencies
>
> try to reduce individual reth- crate dependencies in crates/node by replacing them with a reth_op dependency with the full and cli feature and update the use statements accordingly so they use the re-exported types from reth-op.

## Summary

Migrates `crates/node` to use the `reth-op` meta-crate, reducing individual reth dependencies from 24 to 11.

### Changes:
- Added `reth-op` dependency with `["full", "cli"]` features
- Updated import paths to use reth-op's re-exported modules:
  - `reth_network` → `reth_op::network`
  - `reth_transaction_pool` → `reth_op::pool`
  - `reth_chainspec` → `reth_op::chainspec`
  - `reth_primitives_traits` → `reth_op::primitives`
  - etc.
- Removed 13 individual reth dependencies now accessed through reth-op
- Retained 11 dependencies not fully re-exported by reth-op

All tests pass and the codebase builds successfully.